### PR TITLE
Validator URL now uses https instead of http.

### DIFF
--- a/Services/W3C/HTMLValidator.php
+++ b/Services/W3C/HTMLValidator.php
@@ -44,7 +44,7 @@ class Services_W3C_HTMLValidator
      * 
      * @var string
      */
-    public $validator_uri = 'http://validator.w3.org/check';
+    public $validator_uri = 'https://validator.w3.org/check';
     
     /**
      * The URL of the document to validate


### PR DESCRIPTION
http was getting a permanent redirect to https, but the code doesn't handle redirects. That causes other unexpected errors such as failed parsing of an empty body.